### PR TITLE
Changed icons to the Lucide icon pack used by Obsidian

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -186,7 +186,7 @@ export default class TableSort extends Plugin {
 			table.updateSortingMode(columnIndex);
 			table.updateIcons();
 			table.sort(tableElement, element);
-		});
+		}, { capture: true });
 
 		// When registering intervals, this function will automatically clear the interval when the plugin is disabled.
 		// this.registerInterval(window.setInterval(() => console.log('setInterval'), 5 * 60 * 1000));

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,10 @@ If your plugin does not need CSS, delete this file.
 
 */
 
+:root {
+	--text-color: #fff;
+}
+
 tbody tr:hover {
 	background-color: #444654 !important;
 	color: white;
@@ -23,13 +27,13 @@ th::before {
 }
 
 table:not([class]) th::before, table th.neutral::before {
-	content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='gray'%3E%3Cpath d='M15 8H1l7-8zm0 1H1l7 7z' opacity='.2'/%3E%3C/svg%3E");
+	content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 19' fill='gray' stroke='gray' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='11 17 7 21 3 17'%3E%3C/polyline%3E%3Cline x1='7' y1='21' x2='7' y2='9'%3E%3C/line%3E%3Cpolyline points='21 7 17 3 13 7'%3E%3C/polyline%3E%3Cline x1='17' y1='15' x2='17' y2='3'%3E%3C/line%3E%3C/svg%3E");
 }
 
 table:not([class]) th.ascending::before {
-	content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='gray'%3E%3Cpath d='M15 8H1l7-8z'/%3E%3Cpath d='M15 9H1l7 7z' opacity='.2'/%3E%3C/svg%3E");
+	content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 19' fill='none' stroke='gray' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M11 11h4'%3E%3C/path%3E%3Cpath d='M11 15h7'%3E%3C/path%3E%3Cpath d='M11 19h10'%3E%3C/path%3E%3Cpath d='M9 7 6 4 3 7'%3E%3C/path%3E%3Cpath d='M6 6v14'%3E%3C/path%3E%3C/svg%3E");
 }
 
 table:not([class]) th.descending::before{
-	content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='gray'%3E%3Cpath d='M15 8H1l7-8z' opacity='.2'/%3E%3Cpath d='M15 9H1l7 7z'/%3E%3C/svg%3E");
+	content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 19' fill='none' stroke='gray' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M11 5h10'%3E%3C/path%3E%3Cpath d='M11 9h7'%3E%3C/path%3E%3Cpath d='M11 13h4'%3E%3C/path%3E%3Cpath d='m3 17 3 3 3-3'%3E%3C/path%3E%3Cpath d='M6 18V4'%3E%3C/path%3E%3C/svg%3E");
 }


### PR DESCRIPTION
The following icons were changed to their Lucide alternatives:

- neutral -> arrow-up-down
- ascending -> sort-asc
- descending -> sort-desc