### PR TITLE
Add Table Sorting to Right-Click Menu

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -67,6 +67,72 @@ export default class TableSort extends Plugin {
 		});
 
 
+		this.registerEvent(
+			this.app.workspace.on("editor-menu", (menu, editor, view) => {
+				const cell = document.querySelector("th:hover, td:hover");
+				if (!cell) return;
+				const tableElement = cell.closest(".table-editor");
+				if (!tableElement) return;
+
+				const tableID = this.getTableID(tableElement as HTMLElement);
+				let table: Table;
+				if (this.isNewTable(tableID)) {
+					table = new Table(tableID, tableElement as HTMLTableElement, this);
+					this.storage.push(table);
+				} else {
+					table = this.storage[tableID];
+				}
+				const columnIndex = table.getColumnIndex(cell as HTMLElement);
+				const column = table.getColumn(columnIndex);
+
+				menu.addSeparator();
+				menu.addItem((item) =>
+					item.setTitle("Sort temporarily by column (A to Z)")
+						.setIcon("arrow-up-a-z")
+						.onClick(() => {
+							table.handleClick(column);
+							column.order = "ascending";
+							table.sort();
+							table.updateColumns();
+						})
+				);
+				menu.addItem((item) =>
+					item.setTitle("Sort temporarily by column (Z to A)")
+						.setIcon("arrow-down-z-a")
+						.onClick(() => {
+							table.handleClick(column);
+							column.order = "descending";
+							table.sort();
+							table.updateColumns();
+						})
+				);
+				menu.addItem((item) =>
+					item.setTitle(column.isSelected ? "Deselect" : "Select")
+						.setIcon("check-circle")
+						.onClick(() => {
+							if (column.isSelected) {
+								column.deselect();
+								table.removeFilter(column);
+							} else {
+								column.select();
+								if (!table.containsColumn(column)) {
+									table.filters.push(column);
+								}
+							}
+							table.updateColumns();
+						})
+				);
+				menu.addItem((item) =>
+					item.setTitle("Reset filters")
+						.setIcon("rotate-ccw")
+						.onClick(() => {
+							table.reset();
+						})
+				);
+			})
+		);
+
+
 		TableSort.log("( obsidian-table-sorting ) Plugin has finished loading.");
 	}
 


### PR DESCRIPTION
This PR adds sorting options (A-Z, Z-A, Select/Deselect, Reset filters) to the right-click menu on table headers and cells.

- Uses Obsidian’s official [Context Menus API](https://docs.obsidian.md/Plugins/User+interface/Context+menus).
- Menu items now show up and work as expected.
- Old files like `menuHandler.ts` are still there for you to review.

**Screenshots:**  

Before: 
![image](https://github.com/user-attachments/assets/3fdaaf6d-7afd-4f42-888a-98e35fcf401d)
No menu items, console error.  

After: 
![image](https://github.com/user-attachments/assets/219d8f70-4800-42e0-a330-3f7fc3665f4b)
Menu items show up and work. (Console error still appears due to legacy code.)

Open to feedback or tweaks. Happy coding!